### PR TITLE
Updated commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Checks if your dependencies are up to date in your `pubspec.yaml`.
 # :book: Installation
 
 ```shell
-pub global activate dep_check
+flutter pub global activate dep_check
 ```
 
 In your desired project go and enter.
 
 ```shell
-pub global run dep_check
+flutter pub global run dep_check
 ```


### PR DESCRIPTION
Fix for

pub : The term 'pub' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the    
path is correct and try again.
At line:1 char:1
+ pub global run dep_check
+ ~~~
    + CategoryInfo          : ObjectNotFound: (pub:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException